### PR TITLE
rewind user generator

### DIFF
--- a/src/lib/render.js
+++ b/src/lib/render.js
@@ -13,8 +13,13 @@ const render = async function * (payloadF) {
     if (!generator) {
       payloadProps = yield Promise.resolve(payloadF(payloadProps))
     } else {
-      const { value } = await generator.next(payloadProps)
+      const { value, done } = await generator.next(payloadProps)
       payloadProps = yield Promise.resolve(value)
+
+      // Rewind after user-provided generator `return` statement
+      if (done) {
+        generator = payloadF(payloadProps)
+      }
     }
   }
 }


### PR DESCRIPTION
Instead of having the user handle their generator lifecycle while a while true, let the default be to recreate the generator once it completes.