### PR TITLE
added className to output div

### DIFF
--- a/src/lib/godfather.js
+++ b/src/lib/godfather.js
@@ -92,7 +92,7 @@ export const Godfather = (
   }
 
   return (
-    <div {...getProps(events, handleEvent)}>
+    <div {...getProps(events, handleEvent)} className='react-godfather'>
       {generatorValue}
     </div>
   )


### PR DESCRIPTION
We can't attach events to a React Fragment, so we must use a div instead. Adding a className makes it easier to target in CSS rules, especially in existing projects.

Ref: https://github.com/facebook/react/issues/12051